### PR TITLE
TcpServer not abstract, TcpConnection include get

### DIFF
--- a/HttpServer_AJAX/app/application.cpp
+++ b/HttpServer_AJAX/app/application.cpp
@@ -2,11 +2,12 @@
 #include <SmingCore/SmingCore.h>
 
 // Put you SSID and Password here
-#define WIFI_SSID "PleaseEnterSSID"
-#define WIFI_PWD "PleaseEnterPass"
+#define WIFI_SSID "SSID"
+#define WIFI_PWD "PWD"
 
 HttpServer server;
 FTPServer ftp;
+TcpServer tserver;
 
 int inputs[] = {0, 2}; // Set input GPIO pins here
 Vector<String> namesInput;
@@ -74,6 +75,13 @@ void startWebServer()
 	Serial.println("==============================\r\n");
 }
 
+void startTcpServer()
+{
+	tserver.listen(23);
+
+	Serial.println("\r\n=== TCP SERVER STARTED ===\r\n");
+}
+
 void startFTP()
 {
 	if (!fileExist("index.html"))
@@ -91,11 +99,12 @@ void connectOk()
 
 	startFTP();
 	startWebServer();
+	startTcpServer();
 }
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(74880); // 115200 by default
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 
 	WifiStation.enable(true);

--- a/HttpServer_AJAX/app/application.cpp
+++ b/HttpServer_AJAX/app/application.cpp
@@ -2,12 +2,11 @@
 #include <SmingCore/SmingCore.h>
 
 // Put you SSID and Password here
-#define WIFI_SSID "SSID"
-#define WIFI_PWD "PWD"
+#define WIFI_SSID "PleaseEnterSSID"
+#define WIFI_PWD "PleaseEnterPass"
 
 HttpServer server;
 FTPServer ftp;
-TcpServer tserver;
 
 int inputs[] = {0, 2}; // Set input GPIO pins here
 Vector<String> namesInput;
@@ -75,13 +74,6 @@ void startWebServer()
 	Serial.println("==============================\r\n");
 }
 
-void startTcpServer()
-{
-	tserver.listen(23);
-
-	Serial.println("\r\n=== TCP SERVER STARTED ===\r\n");
-}
-
 void startFTP()
 {
 	if (!fileExist("index.html"))
@@ -99,12 +91,11 @@ void connectOk()
 
 	startFTP();
 	startWebServer();
-	startTcpServer();
 }
 
 void init()
 {
-	Serial.begin(74880); // 115200 by default
+	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 
 	WifiStation.enable(true);

--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -10,15 +10,6 @@
 #include "../../SmingCore/DataSourceStream.h"
 #include "../../Wiring/WString.h"
 
-TcpClient::TcpClient(tcp_pcb *clientTcp, TcpClientDataCallback clientReceive, bool autoDestruct )
-: TcpConnection(clientTcp, autoDestruct), state(eTCS_Ready), asyncTotalSent(0), asyncTotalLen(0)
-{
-	completed = NULL;
-	ready = NULL;
-	receive = clientReceive;
-	debugf("TcpClient instantiated");
-}
-
 TcpClient::TcpClient(bool autoDestruct)
 	: TcpConnection(autoDestruct), state(eTCS_Ready), asyncTotalSent(0), asyncTotalLen(0), asyncCloseAfterSent(false)
 {
@@ -116,14 +107,6 @@ err_t TcpClient::onConnected(err_t err)
 
 err_t TcpClient::onReceive(pbuf *buf)
 {
-	if (receive == NULL)
-	{
-		debugf("TCP Client onReceive, receive = NULL");
-	}
-	else
-	{
-		debugf("TCP Client onReceive, receive not NULL");
-	}
 	if (buf == NULL)
 	{
 		// Disconnected, close it

--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -10,6 +10,15 @@
 #include "../../SmingCore/DataSourceStream.h"
 #include "../../Wiring/WString.h"
 
+TcpClient::TcpClient(tcp_pcb *clientTcp, TcpClientDataCallback clientReceive, bool autoDestruct )
+: TcpConnection(clientTcp, autoDestruct), state(eTCS_Ready), asyncTotalSent(0), asyncTotalLen(0)
+{
+	completed = NULL;
+	ready = NULL;
+	receive = clientReceive;
+	debugf("TcpClient instantiated");
+}
+
 TcpClient::TcpClient(bool autoDestruct)
 	: TcpConnection(autoDestruct), state(eTCS_Ready), asyncTotalSent(0), asyncTotalLen(0), asyncCloseAfterSent(false)
 {
@@ -107,6 +116,14 @@ err_t TcpClient::onConnected(err_t err)
 
 err_t TcpClient::onReceive(pbuf *buf)
 {
+	if (receive == NULL)
+	{
+		debugf("TCP Client onReceive, receive = NULL");
+	}
+	else
+	{
+		debugf("TCP Client onReceive, receive not NULL");
+	}
 	if (buf == NULL)
 	{
 		// Disconnected, close it

--- a/Sming/SmingCore/Network/TcpClient.h
+++ b/Sming/SmingCore/Network/TcpClient.h
@@ -31,6 +31,7 @@ class TcpClient : public TcpConnection
 {
 public:
 	TcpClient(bool autoDestruct);
+	TcpClient(tcp_pcb *clientTcp, TcpClientDataCallback clientReceive, bool autoDestruct);
 	TcpClient(TcpClientBoolCallback onCompleted, TcpClientEventCallback onReadyToSend, TcpClientDataCallback onReceive = NULL);
 	TcpClient(TcpClientBoolCallback onCompleted, TcpClientDataCallback onReceive = NULL);
 	TcpClient(TcpClientDataCallback onReceive);

--- a/Sming/SmingCore/Network/TcpClient.h
+++ b/Sming/SmingCore/Network/TcpClient.h
@@ -31,7 +31,6 @@ class TcpClient : public TcpConnection
 {
 public:
 	TcpClient(bool autoDestruct);
-	TcpClient(tcp_pcb *clientTcp, TcpClientDataCallback clientReceive, bool autoDestruct);
 	TcpClient(TcpClientBoolCallback onCompleted, TcpClientEventCallback onReadyToSend, TcpClientDataCallback onReceive = NULL);
 	TcpClient(TcpClientBoolCallback onCompleted, TcpClientDataCallback onReceive = NULL);
 	TcpClient(TcpClientDataCallback onReceive);

--- a/Sming/SmingCore/Network/TcpConnection.h
+++ b/Sming/SmingCore/Network/TcpConnection.h
@@ -9,7 +9,6 @@
 #define _SMING_CORE_TCPCONNECTION_H_
 
 #include "../Wiring/WiringFrameworkDependencies.h"
-#include "IPAddress.h"
 
 #define NETWORK_DEBUG
 
@@ -52,8 +51,6 @@ public:
 	int write(IDataSourceStream* stream);
 	void flush();
 	void setTimeOut(uint16_t waitTimeOut);
-	IPAddress getRemoteIp() { return IPAddress(tcp->remote_ip) ;};
-	uint16_t getRemotePort() { return tcp->remote_port; };
 
 protected:
 	bool intternalTcpConnect(IPAddress addr, uint16_t port);

--- a/Sming/SmingCore/Network/TcpConnection.h
+++ b/Sming/SmingCore/Network/TcpConnection.h
@@ -9,6 +9,7 @@
 #define _SMING_CORE_TCPCONNECTION_H_
 
 #include "../Wiring/WiringFrameworkDependencies.h"
+#include "IPAddress.h"
 
 #define NETWORK_DEBUG
 
@@ -51,6 +52,8 @@ public:
 	int write(IDataSourceStream* stream);
 	void flush();
 	void setTimeOut(uint16_t waitTimeOut);
+	IPAddress getRemoteIp() { return IPAddress(tcp->remote_ip) ;};
+	uint16_t getRemotePort() { return tcp->remote_port; };
 
 protected:
 	bool intternalTcpConnect(IPAddress addr, uint16_t port);

--- a/Sming/SmingCore/Network/TcpServer.cpp
+++ b/Sming/SmingCore/Network/TcpServer.cpp
@@ -6,7 +6,6 @@
  ****/
 
 #include "TcpServer.h"
-#include "TcpClient.h"
 
 #include "../../SmingCore/Digital.h"
 #include "../../SmingCore/Timer.h"
@@ -21,22 +20,6 @@ TcpServer::TcpServer() : TcpConnection(false)
 
 TcpServer::~TcpServer()
 {
-}
-
-TcpConnection* TcpServer::createClient(tcp_pcb *clientTcp)
-{
-	if (clientTcp == NULL)
-	{
-		debugf("TCP Server createClient NULL\r\n");
-	}
-	else
-	{
-		debugf("TCP Server createClient not NULL");
-	}
-//    clientReceive = (TcpClientDataCallback)&ClientReceive;
-	clientReceive = NULL;
-	TcpConnection* con = new TcpClient(clientTcp, clientReceive, false);
-	return con;
 }
 
 //Timer stateTimer;
@@ -96,7 +79,6 @@ err_t TcpServer::onAccept(tcp_pcb *clientTcp, err_t err)
 
 void TcpServer::onClient(TcpConnection *connection)
 {
-	debugf("Tcp Server onClient ") ; // %s",connection->getRemoteIp().toString().c_str());
 }
 
 err_t TcpServer::staticAccept(void *arg, tcp_pcb *new_tcp, err_t err)

--- a/Sming/SmingCore/Network/TcpServer.cpp
+++ b/Sming/SmingCore/Network/TcpServer.cpp
@@ -6,6 +6,7 @@
  ****/
 
 #include "TcpServer.h"
+#include "TcpClient.h"
 
 #include "../../SmingCore/Digital.h"
 #include "../../SmingCore/Timer.h"
@@ -20,6 +21,22 @@ TcpServer::TcpServer() : TcpConnection(false)
 
 TcpServer::~TcpServer()
 {
+}
+
+TcpConnection* TcpServer::createClient(tcp_pcb *clientTcp)
+{
+	if (clientTcp == NULL)
+	{
+		debugf("TCP Server createClient NULL\r\n");
+	}
+	else
+	{
+		debugf("TCP Server createClient not NULL");
+	}
+//    clientReceive = (TcpClientDataCallback)&ClientReceive;
+	clientReceive = NULL;
+	TcpConnection* con = new TcpClient(clientTcp, clientReceive, false);
+	return con;
 }
 
 //Timer stateTimer;
@@ -79,6 +96,7 @@ err_t TcpServer::onAccept(tcp_pcb *clientTcp, err_t err)
 
 void TcpServer::onClient(TcpConnection *connection)
 {
+	debugf("Tcp Server onClient ") ; // %s",connection->getRemoteIp().toString().c_str());
 }
 
 err_t TcpServer::staticAccept(void *arg, tcp_pcb *new_tcp, err_t err)

--- a/Sming/SmingCore/Network/TcpServer.h
+++ b/Sming/SmingCore/Network/TcpServer.h
@@ -9,7 +9,9 @@
 #define _SMING_CORE_TCPSERVER_H_
 
 #include "TcpConnection.h"
+#include "TcpClient.h"
 
+typedef bool (*TcpClientDataCallback)(TcpClient& client, pbuf *buf);
 
 class TcpServer: public TcpConnection {
 public:
@@ -22,10 +24,12 @@ public:
 
 protected:
 	virtual err_t onAccept(tcp_pcb *clientTcp, err_t err);
-	virtual TcpConnection* createClient(tcp_pcb *clientTcp) = 0;
+	virtual TcpConnection* createClient(tcp_pcb *clientTcp);
 	virtual void onClient(TcpConnection *client);
 
 	static err_t staticAccept(void *arg, tcp_pcb *new_tcp, err_t err);
+
+	TcpClientDataCallback clientReceive;
 
 public:
 	static int16_t totalConnections;

--- a/Sming/SmingCore/Network/TcpServer.h
+++ b/Sming/SmingCore/Network/TcpServer.h
@@ -9,9 +9,7 @@
 #define _SMING_CORE_TCPSERVER_H_
 
 #include "TcpConnection.h"
-#include "TcpClient.h"
 
-typedef bool (*TcpClientDataCallback)(TcpClient& client, pbuf *buf);
 
 class TcpServer: public TcpConnection {
 public:
@@ -24,12 +22,10 @@ public:
 
 protected:
 	virtual err_t onAccept(tcp_pcb *clientTcp, err_t err);
-	virtual TcpConnection* createClient(tcp_pcb *clientTcp);
+	virtual TcpConnection* createClient(tcp_pcb *clientTcp) = 0;
 	virtual void onClient(TcpConnection *client);
 
 	static err_t staticAccept(void *arg, tcp_pcb *new_tcp, err_t err);
-
-	TcpClientDataCallback clientReceive;
 
 public:
 	static int16_t totalConnections;


### PR DESCRIPTION
LS,
I took a different approach to create a "bare tcpserver".
Updated the TcpServer class to not to be abstract -> implemented createClient.
Used TcpClient as TcpConnection for that to get to the receive callback.
However : have trouble getting that implemented in tcpserver class. Can you give me a hint/example ?
Also included getRemoteIp and getRemotePort functions in TcpConnection.
But have trouble actually printing them.
Can you look at TcpServer:onClient and give a hint/example on how to display remote IP ?
Herman