### PR TITLE
TcpServer/TcpClient : When instantiated from tcpserver state should be c...

### DIFF
--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -11,7 +11,7 @@
 #include "../../Wiring/WString.h"
 
 TcpClient::TcpClient(tcp_pcb *clientTcp, TcpClientDataCallback clientReceive, bool autoDestruct )
-: TcpConnection(clientTcp, autoDestruct), state(eTCS_Ready), asyncTotalSent(0), asyncTotalLen(0)
+: TcpConnection(clientTcp, autoDestruct), state(eTCS_Connected), asyncTotalSent(0), asyncTotalLen(0)
 {
 	completed = NULL;
 	ready = NULL;


### PR DESCRIPTION
When using from tcpserver client is already connected.
By setting state to etc_connected the functions send and sendstring will also work correctly.