### PR TITLE
Set autodestruct to true in tcpserver ceateclient to prevent memory leakage

### DIFF
--- a/Sming/SmingCore/Network/TcpConnection.h
+++ b/Sming/SmingCore/Network/TcpConnection.h
@@ -52,8 +52,8 @@ public:
 	int write(IDataSourceStream* stream);
 	void flush();
 	void setTimeOut(uint16_t waitTimeOut);
-	IPAddress getRemoteIp() { return IPAddress(tcp->remote_ip) ;};
-	uint16_t getRemotePort() { return tcp->remote_port; };
+	IPAddress getRemoteIp()  { return (tcp == NULL) ? INADDR_NONE : IPAddress(tcp->remote_ip);};
+	uint16_t getRemotePort() { return (tcp == NULL) ? 0 : tcp->remote_port; };
 
 protected:
 	bool intternalTcpConnect(IPAddress addr, uint16_t port);

--- a/Sming/SmingCore/Network/TcpServer.cpp
+++ b/Sming/SmingCore/Network/TcpServer.cpp
@@ -41,7 +41,7 @@ TcpConnection* TcpServer::createClient(tcp_pcb *clientTcp)
 		debugf("TCP Server createClient not NULL");
 	}
 
-	TcpConnection* con = new TcpClient(clientTcp, clientReceive, false);
+	TcpConnection* con = new TcpClient(clientTcp, clientReceive, true);
 	return con;
 }
 


### PR DESCRIPTION
Set autodestruct to true in tcpserver ceateclient to prevent memory leakage
Update tcpconnection getremoteip/port to test for tcp == null