### PR TITLE
Use SERIAL_BAUD_RATE from user_config.h 

### DIFF
--- a/Basic_WiFi/app/application.cpp
+++ b/Basic_WiFi/app/application.cpp
@@ -51,7 +51,7 @@ void ready()
 
 void init()
 {
-	Serial.begin(115200);
+	Serial.begin(SERIAL_BAUD_RATE);
 	Serial.systemDebugOutput(true); // Allow debug print to serial
 	Serial.println("Sming. Let's do smart things!");
 


### PR DESCRIPTION
Debugging serial baud rate was hard coded at 115200.  This should instead use the value defined in the user_config.h file.