### PR TITLE
LiquidCrystal_44780 pinout information

### DIFF
--- a/LiquidCrystal_44780/README.md
+++ b/LiquidCrystal_44780/README.md
@@ -1,0 +1,13 @@
+# Sming 
+## LiquidCrystal_44780 Example
+
+Example code for I2C LiquidCrystal LCDs
+
+This code uses the following GPIO:
+
+* GPIO0 SCL
+* GPIO2 SDA
+
+# Build instructions
+
+Use `make` and `make flash` to build and flash the firmware to the ESP8266 board.

--- a/LiquidCrystal_44780/app/application.cpp
+++ b/LiquidCrystal_44780/app/application.cpp
@@ -1,3 +1,8 @@
+// LiquidCrystal_I2C example
+// pinout:
+// GPIO0 SCL
+// GPIO2 SDA
+
 #include <user_config.h>
 #include <SmingCore/SmingCore.h>
 #include <Libraries/LiquidCrystal/LiquidCrystal_I2C.h>


### PR DESCRIPTION
I've added information about the pinout for the LiquidCrystal_44780 example.

This information exists on Sming/SmingCore/Wire.h, which is not beginner friendly.

Thanks

