### PR TITLE
NTP example cleanup

### DIFF
--- a/SystemClock_NTP/app/application.cpp
+++ b/SystemClock_NTP/app/application.cpp
@@ -4,15 +4,9 @@
 
 // Put you SSID and Password here
 #define WIFI_SSID "ssid"
-#define WIFI_PWD "pw"
-
-
-void onNtpReceive(NtpClient& client, time_t timestamp);
+#define WIFI_PWD "password"
 
 Timer printTimer;
-//NtpClient ntpClient(onNtpReceive);
-//NtpClient ntpc("fritz.box",30, onNtpReceive);
-
 
 void onPrintSystemTime() {
 	Serial.print("Time    : ");
@@ -21,35 +15,14 @@ void onPrintSystemTime() {
 	Serial.println(SystemClock.getSystemTimeString(true));
 }
 
-
-// Called when time has been received by NtpClient.
-// Either after manual requestTime() or when
-// and automatic request has been made.
-void onNtpReceive(NtpClient& client, time_t timestamp) {
-	SystemClock.setTime(timestamp);
-
-	Serial.print("Time synchronized: ");
-	Serial.println(SystemClock.getSystemTimeString());
-	client.setNtpServer("pool.ntp.org");
-}
-
-NtpClient *nt;
-
 // Will be called when WiFi station was connected to AP
 void connectOk()
 {
-	// Set client to do automatic time requests every 60 seconds.
+	// Set SystemClock to do automatic time sync requests every 60 seconds.
 	// NOTE: you should have longer interval in a real world application
 	// no need for query for time every 60 sec, should be at least 10 minutes or so.
-//	ntpClient.setAutoQueryInterval(30);
-//	ntpClient.setAutoQuery(true);
+	SystemClock.setNtpSync("pool.ntp.org", 60);
 
-	// Request to update time now. 
-	// Otherwise the set interval will pass before time
-	// is updated.
-//	ntpClient.requestTime();
-	SystemClock.setNtpSync("fritz.box",30);
-//	nt = new NtpClient("fritz.box",30);
 }
 
 // Will be called when WiFi station timeout was reached
@@ -62,10 +35,9 @@ void connectFail()
 
 // Will be called when WiFi hardware and software initialization was finished
 // And system initialization was completed
-
 void init()
 {
-	Serial.begin(74880);
+	Serial.begin(SERIAL_BAUD_RATE);
 	Serial.systemDebugOutput(true); // Allow debug print to serial
 	Serial.println("Sming. Let's do smart things!");
 
@@ -74,9 +46,10 @@ void init()
 	WifiStation.config(WIFI_SSID, WIFI_PWD); // Put you SSID and Password here
 
 	SystemClock.setTimezone(2);
-
-	printTimer.initializeMs(1000, onPrintSystemTime).start();
 	
+	// print time periodically
+	printTimer.initializeMs(3000, onPrintSystemTime).start();
+
 	// Run our method when station was connected to AP (or not connected)
 	WifiStation.waitConnection(connectOk, 30, connectFail); // We recommend 20+ seconds at start
 }


### PR DESCRIPTION
I tried to do some cleanup in NTP example. If I understand it correctly.

But I found weird issue.
After 60s when SystemClock should repeat NTP sync request it crash:

```
NtpClient request Time
UDP connect to 81.0.235.220:123
NtpClient request sent
Fatal exception (28):
epc1=0x40002d4e, epc2=0x00000000, epc3=0x00000000, excvaddr=0x13433cb8, depc=0x00000000
rm match
del if0
Fatal exception (28):
epc1=0x40002d4e, epc2=0x00000000, epc3=0x00000000, excvaddr=0x00008000, depc=0x00000000
bcn 0
del if1
usl
sul 0 0
Fatal exception (28):
epc1=0x40002d4e, epc2=0x00000000, epc3=0x00000000, excvaddr=0x00008000, depc=0x00000000

 ets Jan  8 2013,rst cause:4, boot mode:(1,7)

wdt reset
```