### PR TITLE
Use consistent naming for Callback/Delegate and provide macro to defi…

### DIFF
--- a/Sming/SmingCore/Delegate.h
+++ b/Sming/SmingCore/Delegate.h
@@ -10,6 +10,10 @@
 
 #include <user_config.h>
 
+#define DELEGATE_CALLBACK(PARTIAL_NAME, REQTYPE, ...) \
+	using PARTIAL_NAME ## Callback = REQTYPE (*)(__VA_ARGS__); \
+	using PARTIAL_NAME ## Delegate = Delegate<REQTYPE(__VA_ARGS__)>;
+
 
 template<class ReturnType, typename... ParamsList>
 class IDelegateCaller

--- a/Sming/SmingCore/Network/NtpClient.cpp
+++ b/Sming/SmingCore/Network/NtpClient.cpp
@@ -1,7 +1,7 @@
 #include "NtpClient.h"
 
 NtpClient::NtpClient(NtpTimeResultCallback onTimeReceivedCb)
- : NtpClient(NTP_SERVER_DEFAULT, NTP_DEFAULT_AUTO_UPDATE_INTERVAL,NtpClientResultCallback (onTimeReceivedCb)  )
+ : NtpClient(NTP_SERVER_DEFAULT, NTP_DEFAULT_AUTO_UPDATE_INTERVAL,NtpTimeResultDelegate (onTimeReceivedCb)  )
 {
 }
 
@@ -11,13 +11,13 @@ NtpClient::NtpClient()
 }
 
 NtpClient::NtpClient(String reqServer, int reqIntervalSeconds, NtpTimeResultCallback onTimeReceivedCb)
- : NtpClient(reqServer, reqIntervalSeconds, NtpClientResultCallback (onTimeReceivedCb))
+ : NtpClient(reqServer, reqIntervalSeconds, NtpTimeResultDelegate (onTimeReceivedCb))
 {
 }
 
-NtpClient::NtpClient(String reqServer, int reqIntervalSeconds, NtpClientResultCallback delegateFunction /* = NULL */)
+NtpClient::NtpClient(String reqServer, int reqIntervalSeconds, NtpTimeResultDelegate delegateFunction /* = NULL */)
 {
-	autoUpdateTimer.initializeMs(NTP_DEFAULT_AUTO_UPDATE_INTERVAL, Delegate<void()>(&NtpClient::requestTime, this));
+	autoUpdateTimer.initializeMs(NTP_DEFAULT_AUTO_UPDATE_INTERVAL, TimerDelegate(&NtpClient::requestTime, this));
 	this->server = reqServer;
 	this->delegateCompleted = delegateFunction;
 	if (!delegateFunction)
@@ -69,7 +69,7 @@ void NtpClient::requestTime()
 {
 	if (!WifiStation.isConnected())
 	{
-		connectionTimer.initializeMs(1000, Delegate<void()>(&NtpClient::requestTime, this)).startOnce();
+		connectionTimer.initializeMs(1000, TimerDelegate(&NtpClient::requestTime, this)).startOnce();
 		return;
 	}
 	if (serverAddress.isNull())

--- a/Sming/SmingCore/Network/NtpClient.h
+++ b/Sming/SmingCore/Network/NtpClient.h
@@ -20,8 +20,8 @@
 
 class NtpClient;
 
-typedef void (*NtpTimeResultCallback)(NtpClient& client, time_t ntpTime);
-typedef Delegate<void(NtpClient& client, time_t ntpTime)> NtpClientResultCallback;
+// Define Callback and Delegate
+DELEGATE_CALLBACK (NtpTimeResult,void,NtpClient& client, time_t ntpTime)
 
 class NtpClient : protected UdpConnection
 {
@@ -30,7 +30,7 @@ public:
 	NtpClient();
 	NtpClient(NtpTimeResultCallback onTimeReceivedCb);
 	NtpClient(String reqServer, int reqIntervalSeconds, NtpTimeResultCallback onTimeReceivedCb);
-	NtpClient(String reqServer, int reqIntervalSeconds, NtpClientResultCallback delegateFunction = NULL);
+	NtpClient(String reqServer, int reqIntervalSeconds, NtpTimeResultDelegate delegateFunction = NULL);
 	virtual ~NtpClient();
 
 	void requestTime();
@@ -50,7 +50,7 @@ protected:
 protected: 
 	String server = NTP_SERVER_DEFAULT;
 	IPAddress serverAddress = (uint32_t)0;
-	NtpClientResultCallback delegateCompleted = nullptr;
+	NtpTimeResultDelegate delegateCompleted = nullptr;
 	bool autoUpdateSystemClock = false;
 		
 	Timer autoUpdateTimer;

--- a/Sming/SmingCore/Timer.cpp
+++ b/Sming/SmingCore/Timer.cpp
@@ -16,28 +16,28 @@ Timer::~Timer()
 	stop();
 }
 
-Timer& Timer::initializeMs(uint32_t milliseconds, InterruptCallback callback/* = NULL*/)
+Timer& Timer::initializeMs(uint32_t milliseconds, TimerCallback callback/* = NULL*/)
 {
 	setCallback(callback);
 	setIntervalMs(milliseconds);
 	return *this;
 }
 
-Timer& Timer::initializeUs(uint32_t microseconds, InterruptCallback callback/* = NULL*/)
+Timer& Timer::initializeUs(uint32_t microseconds, TimerCallback callback/* = NULL*/)
 {
 	setCallback(callback);
 	setIntervalUs(microseconds);
 	return *this;
 }
 
-Timer& Timer::initializeMs(uint32_t milliseconds, Delegate<void()> delegateFunction)
+Timer& Timer::initializeMs(uint32_t milliseconds, TimerDelegate delegateFunction)
 {
 	setCallback(delegateFunction);
 	setIntervalMs(milliseconds);
 	return *this;
 }
 
-Timer& Timer::initializeUs(uint32_t microseconds, Delegate<void()> delegateFunction)
+Timer& Timer::initializeUs(uint32_t microseconds, TimerDelegate delegateFunction)
 {
 	setCallback(delegateFunction);
 	setIntervalUs(microseconds);
@@ -49,10 +49,10 @@ void Timer::start(bool repeating/* = true*/)
 	stop();
 	if(interval == 0 || (!callback && !delegate_func)) return;
 	ets_timer_setfn(&timer, (os_timer_func_t *)processing, this);
-	if (interval > 10000)
-		ets_timer_arm_new(&timer, (uint32_t)(interval / 1000), repeating, 1); // msec
+	if (interval > 1000)
+		ets_timer_arm_new(&timer, interval / 1000, repeating, 1); // msec
 	else
-		ets_timer_arm_new(&timer, (uint32_t)interval, repeating, 0); 		  // usec
+		ets_timer_arm_new(&timer, interval, repeating, 0); 		  // usec
 	started = true;
 }
 
@@ -96,7 +96,7 @@ void Timer::setIntervalMs(uint32_t milliseconds/* = 1000000*/)
 	setIntervalUs(((uint64_t)milliseconds) * 1000);
 }
 
-void Timer::setCallback(InterruptCallback interrupt/* = NULL*/)
+void Timer::setCallback(TimerCallback interrupt/* = NULL*/)
 {
 	ETS_INTR_LOCK();
 	callback = interrupt;
@@ -107,7 +107,7 @@ void Timer::setCallback(InterruptCallback interrupt/* = NULL*/)
 		stop();
 }
 
-void Timer::setCallback(Delegate<void()> delegateFunction)
+void Timer::setCallback(TimerDelegate delegateFunction)
 {
 	ETS_INTR_LOCK();
 	callback = nullptr;

--- a/Sming/SmingCore/Timer.h
+++ b/Sming/SmingCore/Timer.h
@@ -12,6 +12,9 @@
 #include "../SmingCore/Delegate.h"
 #include "../Wiring/WiringFrameworkDependencies.h"
 
+//Define Callback and Delegate type void, no parameters
+DELEGATE_CALLBACK (Timer,void)
+
 class Timer
 {
 public:
@@ -21,11 +24,11 @@ public:
 	// It return value for Method Chaining (return "this" reference)
 	// http://en.wikipedia.org/wiki/Method_chaining
 
-	Timer& IRAM_ATTR initializeMs(uint32_t milliseconds, InterruptCallback callback = NULL); // Init in Milliseconds.
-	Timer& IRAM_ATTR initializeUs(uint32_t microseconds, InterruptCallback callback = NULL); // Init in Microseconds.
+	Timer& IRAM_ATTR initializeMs(uint32_t milliseconds, TimerCallback callback = NULL); // Init in Milliseconds.
+	Timer& IRAM_ATTR initializeUs(uint32_t microseconds, TimerCallback callback = NULL); // Init in Microseconds.
 
-	Timer& IRAM_ATTR initializeMs(uint32_t milliseconds, Delegate<void()> delegateFunction = NULL); // Init in Milliseconds.
-	Timer& IRAM_ATTR initializeUs(uint32_t microseconds, Delegate<void()> delegateFunction = NULL); // Init in Microseconds.
+	Timer& IRAM_ATTR initializeMs(uint32_t milliseconds, TimerDelegate delegateFunction = NULL); // Init in Milliseconds.
+	Timer& IRAM_ATTR initializeUs(uint32_t microseconds, TimerDelegate delegateFunction = NULL); // Init in Microseconds.
 
 	void IRAM_ATTR start(bool repeating = true);
 	void __forceinline IRAM_ATTR startOnce() { start(false); }
@@ -39,18 +42,18 @@ public:
     void IRAM_ATTR setIntervalUs(uint32_t microseconds = 1000000);
     void IRAM_ATTR setIntervalMs(uint32_t milliseconds = 1000000);
 
-    void IRAM_ATTR setCallback(InterruptCallback interrupt = NULL);
-    void IRAM_ATTR setCallback(Delegate<void()> delegateFunction);
+    void IRAM_ATTR setCallback(TimerCallback interrupt = NULL);
+    void IRAM_ATTR setCallback(TimerDelegate delegateFunction);
 
 protected:
     static void IRAM_ATTR processing(void *arg);
 
 
 private:
-    os_timer_t timer;
+    os_timer_t timer STORE_ATTR;
     uint64_t interval = 0;
-    InterruptCallback callback = nullptr;
-    Delegate<void()> delegate_func = nullptr;
+    TimerCallback callback = nullptr;
+    TimerDelegate delegate_func = nullptr;
     bool started = false;
 };
 

--- a/SystemClock_NTP/app/application.cpp
+++ b/SystemClock_NTP/app/application.cpp
@@ -11,11 +11,11 @@ class ntpClientDemo
 public:
 	ntpClientDemo()
 	{
-		ntpResultCB = NtpClientResultCallback(&ntpClientDemo::ntpResult, this);
+		ntpResultCB = NtpTimeResultDelegate(&ntpClientDemo::ntpResult, this);
 		ntpcp = new NtpClient("pool.ntp.org", 30, ntpResultCB);
 
 		// 			Alternative way without private member variable
-		//	 		ntpcp = new NtpClient("pool.ntp.org",30, NtpClientResultCallback (&ntpClientDemo::ntpResult, this));
+		//	 		ntpcp = new NtpClient("pool.ntp.org",30, NtpTimeResultDelegate (&ntpClientDemo::ntpResult, this));
 
 	};
 	~ntpClientDemo() {};
@@ -33,7 +33,7 @@ public:
 		return true;
 	}
 
-	NtpClientResultCallback ntpResultCB = NtpClientResultCallback(&ntpClientDemo::ntpResult, this);
+	NtpTimeResultDelegate ntpResultCB = NtpTimeResultDelegate(&ntpClientDemo::ntpResult, this);
 
 };
 


### PR DESCRIPTION
…ne them

Implemented in delegate.h If you want another location please let me know
Used in Timer, NtpClient and SystemClock_NTP example application
f.e. : 
DELEGATE_CALLBACK(Test,void,int req) defines
TestCallback and TestDelegate as void functions accepting int as parameter

I created this because I spent a lot of time searching for issue, finding that I had a small discrepancy in the definition of callback and delegate.
