### PR TITLE
Add Full Control option to HardwareSerial Callback

### DIFF
--- a/Basic_Serial/app/application.cpp
+++ b/Basic_Serial/app/application.cpp
@@ -13,7 +13,7 @@ void sayHello()
 	Serial.println();
 }
 
-void hwsDelegate(Stream& stream, unsigned short charCount)
+void onDataCallback(Stream& stream, char recvChar, unsigned short charCount)
 {
 
 }

--- a/Basic_Serial/include/SerialReadingDelegateDemo.h
+++ b/Basic_Serial/include/SerialReadingDelegateDemo.h
@@ -11,12 +11,22 @@ public:
 		debugf("hwsDelegateDemo instantiated, waiting for data");
 	};
 
-	void hwsDelegate(Stream& stream, unsigned short charCount)
+	void hwsDelegate(Stream& stream, char recvChar, unsigned short charCount)
 	{
 		Serial.print("hwsDelegateDemo Delegate Time = ");
 		Serial.print(micros());
 		Serial.print(" charCount = ");
-		Serial.println(charCount);
+		Serial.print(charCount);
+		Serial.print(" character = ");
+		Serial.println(recvChar);
+
+		numCallback++;
+
+		if (recvChar == 'X') // Toggle useRxBuff
+		{
+			useRxFlag = !useRxFlag;
+			Serial.setCallback(StreamDataAvailableDelegate(&SerialReadingDelegateDemo::hwsDelegate,this),useRxFlag);
+		}
 
 		if (charCount >= 10) // Just for example
 		{
@@ -34,6 +44,8 @@ public:
 
 private:
 	unsigned charReceived = 0;
+	unsigned numCallback = 0;
+	bool useRxFlag = true;
 };
 
 

--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -15,8 +15,16 @@
 #define UART_ID_0   0
 #define UART_ID_1   1
 
+#define NUMBER_UARTS 2
+
 // Delegate constructor usage: (&YourClass::method, this)
-typedef Delegate<void(Stream &self, uint16_t availableCount)> StreamDataAvailableDelegate;
+typedef Delegate<void(Stream &self, char recvChar, uint16_t availableCount)> StreamDataAvailableDelegate;
+
+typedef struct
+{
+	StreamDataAvailableDelegate HWSDelegate;
+	bool useRxBuff;
+} MemberData;
 
 class HardwareSerial : public Stream
 {
@@ -35,14 +43,14 @@ public:
 
 	//void printf(const char *fmt, ...);
 	void systemDebugOutput(bool enabled);
-	void setCallback(StreamDataAvailableDelegate reqCallback);
+	void setCallback(StreamDataAvailableDelegate reqCallback, bool reqUseRxBuff = true);
 	void resetCallback();
 
 	static void IRAM_ATTR uart0_rx_intr_handler(void *para);
 
 private:
 	int uart;
-	static StreamDataAvailableDelegate HWSDelegates[2];
+	static MemberData memberData[NUMBER_UARTS];
 
 };
 


### PR DESCRIPTION
By adding "Character Received"and option not to use HWSerial buffer a user can take full control over HWS input