### PR TITLE
Add Printf to print.cpp and update basic serial example

### DIFF
--- a/Basic_Serial/app/application.cpp
+++ b/Basic_Serial/app/application.cpp
@@ -4,6 +4,7 @@
 
 Timer procTimer;
 SerialReadingDelegateDemo delegateDemoClass;
+int helloCounter = 0;
 
 void sayHello()
 {
@@ -11,6 +12,8 @@ void sayHello()
 	Serial.print(" Time : ");
 	Serial.println(micros());
 	Serial.println();
+
+	Serial.printf("This is Hello message %d \r\n", ++helloCounter);
 }
 
 void init()

--- a/Sming/Wiring/Print.cpp
+++ b/Sming/Wiring/Print.cpp
@@ -197,6 +197,33 @@ size_t Print::println(const Printable &p)
   return n;
 }
 
+size_t Print::printf(const char *fmt, ...)
+{
+	size_t sz = 0;
+	size_t buffSize = INITIAL_PRINTF_BUFFSIZE;
+	bool retry = false;
+	do {
+		char tempBuff[buffSize];
+		va_list va;
+		va_start(va, fmt);
+		sz = ets_vsnprintf(tempBuff,buffSize, fmt, va);
+		va_end(va);
+		if (sz > (buffSize -1))
+		{
+			buffSize = sz + 1; // Leave room for terminating null char
+			retry = true;
+		}
+		else
+		{
+			if (sz > 0)
+			{
+				write(tempBuff,sz);
+			}
+			return sz;
+		}
+	} while (retry);
+}
+
 // private methods
 
 size_t Print::printNumber(unsigned long n, uint8_t base)

--- a/Sming/Wiring/Print.h
+++ b/Sming/Wiring/Print.h
@@ -24,6 +24,8 @@
 #include "WiringFrameworkDependencies.h"
 #include "Printable.h"
 
+#define INITIAL_PRINTF_BUFFSIZE 128
+
 class String;
 
 class Print
@@ -81,6 +83,9 @@ class Print
 
     size_t println(const Printable &p);
     size_t println(const String &s);
+
+    // printf
+    size_t printf(const char *fmt, ...);
 
   private:
     int write_error;

--- a/Sming/system/include/esp_systemapi.h
+++ b/Sming/system/include/esp_systemapi.h
@@ -14,6 +14,8 @@
 #include "espinc/uart_register.h"
 #include "espinc/spi_register.h"
 
+#include <stdarg.h>
+
 #include <user_config.h>
 
 #define __ESP8266_EX__ // System definition ESP8266 SOC
@@ -60,6 +62,7 @@ extern char *ets_strncpy(char *dest, const char *src, size_t n);
 extern char *ets_strstr(const char *haystack, const char *needle);
 extern int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
 extern int os_snprintf(char *str, size_t size, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
+extern int ets_vsnprintf(char * s, size_t n, const char * format, va_list arg) __attribute__ ((format (printf, 3, 0)));
 
 extern void *pvPortMalloc(size_t xWantedSize);
 extern void *pvPortZalloc(size_t);


### PR DESCRIPTION
Added printf function to print.cpp.
In this way available for all "Serial" -> also for HardwareSerial.
