### PR TITLE
[makefile] Add flexibility for own project folders + debug info

### DIFF
--- a/Accelerometer_MMA7455/Makefile-user.mk
+++ b/Accelerometer_MMA7455/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/Basic_AirUpdate/Makefile-user.mk
+++ b/Basic_AirUpdate/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/Basic_Blink/Makefile-user.mk
+++ b/Basic_Blink/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/Basic_Interrupts/Makefile-user.mk
+++ b/Basic_Interrupts/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/Basic_PWM/Makefile-user.mk
+++ b/Basic_PWM/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/Basic_ScannerI2C/Makefile-user.mk
+++ b/Basic_ScannerI2C/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/Basic_Serial/Makefile-user.mk
+++ b/Basic_Serial/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/Basic_SmartConfig/Makefile-user.mk
+++ b/Basic_SmartConfig/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/Basic_WiFi/Makefile-user.mk
+++ b/Basic_WiFi/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/Compass_HMC5883L/Makefile-user.mk
+++ b/Compass_HMC5883L/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/FtpServer_Files/.settings/language.settings.xml
+++ b/FtpServer_Files/.settings/language.settings.xml
@@ -5,10 +5,6 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider copy-of="extension" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser"/>
-			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="128979901708853748" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
-				<language-scope id="org.eclipse.cdt.core.gcc"/>
-				<language-scope id="org.eclipse.cdt.core.g++"/>
-			</provider>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
 		</extension>
 	</configuration>

--- a/FtpServer_Files/.settings/language.settings.xml
+++ b/FtpServer_Files/.settings/language.settings.xml
@@ -5,6 +5,10 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider copy-of="extension" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser"/>
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="128979901708853748" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+				<language-scope id="org.eclipse.cdt.core.gcc"/>
+				<language-scope id="org.eclipse.cdt.core.g++"/>
+			</provider>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
 		</extension>
 	</configuration>

--- a/FtpServer_Files/Makefile-user.mk
+++ b/FtpServer_Files/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/HttpClient_Instapush/Makefile-user.mk
+++ b/HttpClient_Instapush/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/HttpClient_ThingSpeak/Makefile-user.mk
+++ b/HttpClient_ThingSpeak/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/HttpServer_AJAX/Makefile-user.mk
+++ b/HttpServer_AJAX/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/HttpServer_Bootstrap/.settings/language.settings.xml
+++ b/HttpServer_Bootstrap/.settings/language.settings.xml
@@ -5,10 +5,6 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider copy-of="extension" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser"/>
-			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="128979901708853748" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
-				<language-scope id="org.eclipse.cdt.core.gcc"/>
-				<language-scope id="org.eclipse.cdt.core.g++"/>
-			</provider>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
 		</extension>
 	</configuration>

--- a/HttpServer_Bootstrap/.settings/language.settings.xml
+++ b/HttpServer_Bootstrap/.settings/language.settings.xml
@@ -5,6 +5,10 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider copy-of="extension" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser"/>
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="128979901708853748" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+				<language-scope id="org.eclipse.cdt.core.gcc"/>
+				<language-scope id="org.eclipse.cdt.core.g++"/>
+			</provider>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
 		</extension>
 	</configuration>

--- a/HttpServer_Bootstrap/Makefile-user.mk
+++ b/HttpServer_Bootstrap/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/HttpServer_ConfigNetwork/Makefile-user.mk
+++ b/HttpServer_ConfigNetwork/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/Humidity_DHT22/Makefile-user.mk
+++ b/Humidity_DHT22/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/LED_WS2812/Makefile-user.mk
+++ b/LED_WS2812/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/Light_BH1750/Makefile-user.mk
+++ b/Light_BH1750/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/LiquidCrystal_44780/Makefile-user.mk
+++ b/LiquidCrystal_44780/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/MeteoControl/Makefile-user.mk
+++ b/MeteoControl/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/MqttClient_Hello/Makefile-user.mk
+++ b/MqttClient_Hello/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/Pressure_BMP180/Makefile-user.mk
+++ b/Pressure_BMP180/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/ScreenLCD_5110/Makefile-user.mk
+++ b/ScreenLCD_5110/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/ScreenOLED_SSD1306/Makefile-user.mk
+++ b/ScreenOLED_SSD1306/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/ScreenTFT_ILI9163C/Makefile-user.mk
+++ b/ScreenTFT_ILI9163C/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/ScreenTFT_ILI9340-ILI9341/Makefile-user.mk
+++ b/ScreenTFT_ILI9340-ILI9341/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -108,7 +108,7 @@ TARGET		= app
 
 # which modules (subdirectories) of the project to include in compiling
 # define your custom directories in the project's own Makefile before including this one
-MODULES		+= $(SMING_HOME)/appinit app
+MODULES		+= $(SMING_HOME)/appinit
 EXTRA_INCDIR    ?= include $(SMING_HOME)/include $(SMING_HOME)/ $(SMING_HOME)/system/include $(SMING_HOME)/Wiring $(SMING_HOME)/Libraries $(SMING_HOME)/SmingCore $(SDK_BASE)/../include
 
 # libraries used in this project, mainly provided by the SDK
@@ -318,6 +318,7 @@ spiff_update: spiff_clean $(SPIFF_BIN_OUT)
 $(TARGET_OUT): $(APP_AR)
 	$(vecho) "LD $@"	
 	$(Q) $(LD) -L$(USER_LIBDIR) -L$(SDK_LIBDIR) $(LD_SCRIPT) $(LDFLAGS) -Wl,--start-group $(LIBS) $(APP_AR) -Wl,--end-group -o $@
+ifeq ($(UNAME),Windows)	
 	$(vecho) "------------------------------------------------------------------------------"
 	$(vecho) "Section info:"
 	$(Q) $(OBJDUMP) -h -j .data -j .rodata -j .bss -j .text -j .irom0.text $@
@@ -325,6 +326,7 @@ $(TARGET_OUT): $(APP_AR)
 	$(vecho) "Section info:"
 	$(Q) $(SDK_TOOLS)/memanalyzer.exe $(OBJDUMP).exe $@
 	$(vecho) "------------------------------------------------------------------------------"
+endif	
 	$(vecho) "Running objcopy, please wait..."	
 	$(Q) $(OBJCOPY) --only-section .text -O binary $@ eagle.app.v6.text.bin
 	$(Q) $(OBJCOPY) --only-section .data -O binary $@ eagle.app.v6.data.bin

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -107,7 +107,8 @@ SPIFF_START_OFFSET = $(shell printf '0x%X\n' $$(( ($$($(GET_FILESIZE) $(FW_BASE)
 TARGET		= app
 
 # which modules (subdirectories) of the project to include in compiling
-MODULES		?= $(SMING_HOME)/appinit app
+# define your custom directories in the project's own Makefile before including this one
+MODULES		+= $(SMING_HOME)/appinit app
 EXTRA_INCDIR    ?= include $(SMING_HOME)/include $(SMING_HOME)/ $(SMING_HOME)/system/include $(SMING_HOME)/Wiring $(SMING_HOME)/Libraries $(SMING_HOME)/SmingCore $(SDK_BASE)/../include
 
 # libraries used in this project, mainly provided by the SDK
@@ -317,6 +318,13 @@ spiff_update: spiff_clean $(SPIFF_BIN_OUT)
 $(TARGET_OUT): $(APP_AR)
 	$(vecho) "LD $@"	
 	$(Q) $(LD) -L$(USER_LIBDIR) -L$(SDK_LIBDIR) $(LD_SCRIPT) $(LDFLAGS) -Wl,--start-group $(LIBS) $(APP_AR) -Wl,--end-group -o $@
+	$(vecho) "------------------------------------------------------------------------------"
+	$(vecho) "Section info:"
+	$(Q) $(OBJDUMP) -h -j .data -j .rodata -j .bss -j .text -j .irom0.text $@
+	$(vecho) "------------------------------------------------------------------------------"
+	$(vecho) "Section info:"
+	$(Q) $(SDK_TOOLS)/memanalyzer.exe $(OBJDUMP).exe $@
+	$(vecho) "------------------------------------------------------------------------------"
 	$(vecho) "Running objcopy, please wait..."	
 	$(Q) $(OBJCOPY) --only-section .text -O binary $@ eagle.app.v6.text.bin
 	$(Q) $(OBJCOPY) --only-section .data -O binary $@ eagle.app.v6.data.bin

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -318,15 +318,10 @@ spiff_update: spiff_clean $(SPIFF_BIN_OUT)
 $(TARGET_OUT): $(APP_AR)
 	$(vecho) "LD $@"	
 	$(Q) $(LD) -L$(USER_LIBDIR) -L$(SDK_LIBDIR) $(LD_SCRIPT) $(LDFLAGS) -Wl,--start-group $(LIBS) $(APP_AR) -Wl,--end-group -o $@
-ifeq ($(UNAME),Windows)	
 	$(vecho) "------------------------------------------------------------------------------"
 	$(vecho) "Section info:"
 	$(Q) $(OBJDUMP) -h -j .data -j .rodata -j .bss -j .text -j .irom0.text $@
 	$(vecho) "------------------------------------------------------------------------------"
-	$(vecho) "Section info:"
-	$(Q) $(SDK_TOOLS)/memanalyzer.exe $(OBJDUMP).exe $@
-	$(vecho) "------------------------------------------------------------------------------"
-endif	
 	$(vecho) "Running objcopy, please wait..."	
 	$(Q) $(OBJCOPY) --only-section .text -O binary $@ eagle.app.v6.text.bin
 	$(Q) $(OBJCOPY) --only-section .data -O binary $@ eagle.app.v6.data.bin

--- a/SystemClock_NTP/Makefile-user.mk
+++ b/SystemClock_NTP/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/TcpClient_NarodMon/Makefile-user.mk
+++ b/TcpClient_NarodMon/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/Temperature_DS1820/Makefile-user.mk
+++ b/Temperature_DS1820/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/UdpServer_Echo/Makefile-user.mk
+++ b/UdpServer_Echo/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif

--- a/Ultrasonic_HCSR04/Makefile-user.mk
+++ b/Ultrasonic_HCSR04/Makefile-user.mk
@@ -2,6 +2,9 @@
 ## Parameters configured here will override default and ENV values.
 ## Uncomment and change examples:
 
+#Add your source directories here separated by space
+MODULES = app
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif


### PR DESCRIPTION
This alloows me to have other module/source folders/subfolders besides the "app". These folders can be configured by defining MODULES var in own project Makefile before including the SmingCore Makefile.
Also memory size information added at the end of the build process.