### PR TITLE
One TcpClient constructor missed the , asyncCloseAfterSent(false) init

### DIFF
--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -11,46 +11,36 @@
 #include "../../Wiring/WString.h"
 
 TcpClient::TcpClient(tcp_pcb *clientTcp, TcpClientDataCallback clientReceive, bool autoDestruct )
-: TcpConnection(clientTcp, autoDestruct), state(eTCS_Connected), asyncTotalSent(0), asyncTotalLen(0), asyncCloseAfterSent(false)
+: TcpConnection(clientTcp, autoDestruct), state(eTCS_Connected)
 {
-	completed = NULL;
-	ready = NULL;
 	receive = clientReceive;
-	stream = NULL;
 }
 
 TcpClient::TcpClient(bool autoDestruct)
-	: TcpConnection(autoDestruct), state(eTCS_Ready), asyncTotalSent(0), asyncTotalLen(0), asyncCloseAfterSent(false)
+	: TcpConnection(autoDestruct), state(eTCS_Ready)
 {
-	completed = NULL;
-	ready = NULL;
-	receive = NULL;
-	stream = NULL;
 }
 
 TcpClient::TcpClient(TcpClientBoolCallback onCompleted, TcpClientEventCallback onReadyToSend /* = NULL*/, TcpClientDataCallback onReceive /* = NULL*/)
-	: TcpConnection(false), state(eTCS_Ready), asyncTotalSent(0), asyncTotalLen(0), asyncCloseAfterSent(false)
+	: TcpConnection(false), state(eTCS_Ready)
 {
 	completed = onCompleted;
 	ready = onReadyToSend;
 	receive = onReceive;
-	stream = NULL;
 }
 
 TcpClient::TcpClient(TcpClientBoolCallback onCompleted, TcpClientDataCallback onReceive /* = NULL*/)
-	: TcpConnection(false), state(eTCS_Ready), ready(NULL), asyncTotalSent(0), asyncTotalLen(0), asyncCloseAfterSent(false)
+	: TcpConnection(false), state(eTCS_Ready)
 {
 	completed = onCompleted;
 	receive = onReceive;
-	stream = NULL;
 }
 
 
 TcpClient::TcpClient(TcpClientDataCallback onReceive)
-	: TcpConnection(false), state(eTCS_Ready), ready(NULL), completed(NULL), asyncTotalSent(0), asyncTotalLen(0), asyncCloseAfterSent(false)
+	: TcpConnection(false), state(eTCS_Ready)
 {
 	receive = onReceive;
-	stream = NULL;
 }
 
 TcpClient::~TcpClient()

--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -11,7 +11,7 @@
 #include "../../Wiring/WString.h"
 
 TcpClient::TcpClient(tcp_pcb *clientTcp, TcpClientDataCallback clientReceive, bool autoDestruct )
-: TcpConnection(clientTcp, autoDestruct), state(eTCS_Connected), asyncTotalSent(0), asyncTotalLen(0)
+: TcpConnection(clientTcp, autoDestruct), state(eTCS_Connected), asyncTotalSent(0), asyncTotalLen(0), asyncCloseAfterSent(false)
 {
 	completed = NULL;
 	ready = NULL;

--- a/Sming/SmingCore/Network/TcpClient.h
+++ b/Sming/SmingCore/Network/TcpClient.h
@@ -64,13 +64,13 @@ protected:
 
 private:
 	TcpClientState state;
-	TcpClientBoolCallback completed;
-	TcpClientDataCallback receive;
-	TcpClientEventCallback ready;
-	MemoryDataStream* stream;
-	bool asyncCloseAfterSent;
-	int16_t asyncTotalSent;
-	int16_t asyncTotalLen;
+	TcpClientBoolCallback completed = nullptr;
+	TcpClientDataCallback receive = nullptr;
+	TcpClientEventCallback ready = nullptr;
+	MemoryDataStream* stream = nullptr;
+	bool asyncCloseAfterSent = false;
+	int16_t asyncTotalSent = 0;
+	int16_t asyncTotalLen = 0;
 };
 
 #endif /* _SMING_CORE_TCPCLIENT_H_ */


### PR DESCRIPTION
Found this missing initialization during my telnet testing