### PR TITLE
Improve pullup handling for Arduino compat

### DIFF
--- a/Sming/SmingCore/Digital.h
+++ b/Sming/SmingCore/Digital.h
@@ -22,6 +22,8 @@ uint8_t digitalRead(uint16_t pin);
 void pullup(uint16_t pin);
 void noPullup(uint16_t pin);
 
+bool isInputPin(uint16_t pin);
+
 unsigned long pulseIn(uint16_t pin, uint8_t state, unsigned long timeout =
 		1000000L);
 #endif

--- a/Sming/Wiring/WConstants.h
+++ b/Sming/Wiring/WConstants.h
@@ -40,8 +40,9 @@
 #define HIGH     0x1
 //#define HIGH     0xFF
 
-#define INPUT    0x0
-#define OUTPUT   0x1
+#define INPUT        0x0
+#define OUTPUT       0x1
+#define INPUT_PULLUP 0x2 //defined in Arduino > 100
 //#define OUTPUT   0xFF
 
 #define CHANGE   32 // to avoid conflict with HIGH value


### PR DESCRIPTION
Currently pullup is enabled by default.
To better emulate Arduino there are 2 cases
1. for versions pre 1.0.1 - pupllup is enabled by setting pinMode(INPUT) and then digitalWrite(HIGH)
2. for version post 1.0.1  - A new mode exists INPUT_PULLUP - pullup is enabled by setting the pinMode(INPUT_PULLUP)

See https://www.arduino.cc/en/Tutorial/DigitalPins
