### PR TITLE
TCPClient re-initializy async variables after finishing connection

### DIFF
--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -205,6 +205,9 @@ void TcpClient::onFinished(TcpClientState finishState)
 	if (stream != NULL)
 		delete stream; // Free memory now!
 	stream = NULL;
+	// Initialize async variables for next connection
+	asyncTotalSent = 0;
+	asyncTotalLen = 0;
 
 	if (completed)
 		completed(*this, state == eTCS_Successful);


### PR DESCRIPTION
TCPClient does not re-initialize variables after finish connection.
This gives errors in the next use (connect) of the TcpClient.

PS : Solving was combined effort with @flexiti 

Should at least fix issue #174 and possible #198 (needs to be re-tested) 