### PR TITLE
Fixes for Ntp, Rtc and Timer

### DIFF
--- a/Sming/SmingCore/Network/NtpClient.cpp
+++ b/Sming/SmingCore/Network/NtpClient.cpp
@@ -1,18 +1,25 @@
 #include "NtpClient.h"
 
 NtpClient::NtpClient()
- : NtpClient(NTP_SERVER_DEFAULT, NTP_DEFAULT_AUTO_UPDATE_INTERVAL, nullptr)
+ : NtpClient(NTP_DEFAULT_SERVER, NTP_DEFAULT_QUERY_INTERVAL_SECONDS, nullptr)
 {
 }
 
 NtpClient::NtpClient(NtpTimeResultDelegate onTimeReceivedCb)
- : NtpClient(NTP_SERVER_DEFAULT, NTP_DEFAULT_AUTO_UPDATE_INTERVAL, onTimeReceivedCb)
+ : NtpClient(NTP_DEFAULT_SERVER, NTP_DEFAULT_QUERY_INTERVAL_SECONDS, onTimeReceivedCb)
 {
 }
 
 NtpClient::NtpClient(String reqServer, int reqIntervalSeconds, NtpTimeResultDelegate delegateFunction /* = NULL */)
 {
-	autoUpdateTimer.initializeMs(NTP_DEFAULT_AUTO_UPDATE_INTERVAL, TimerDelegate(&NtpClient::requestTime, this));
+	// init timer but do not start, correct interval set later below.
+	autoUpdateTimer.initializeMs(NTP_DEFAULT_QUERY_INTERVAL_SECONDS * 1000,
+			TimerDelegate(&NtpClient::requestTime, this));
+
+	timeoutTimer.initializeMs(NTP_RESPONSE_TIMEOUT_MS,
+			TimerDelegate(&NtpClient::requestTime, this));
+
+
 	this->server = reqServer;
 	this->delegateCompleted = delegateFunction;
 	if (!delegateFunction)
@@ -30,35 +37,12 @@ NtpClient::NtpClient(String reqServer, int reqIntervalSeconds, NtpTimeResultDele
 		setAutoQuery(true);
 		requestTime();
 	}
-
 }
 
 NtpClient::~NtpClient()
 {
 }
 
-int NtpClient::resolveServer()
-{
-	if (this->server != NULL)
-	{
-		struct ip_addr resolved;
-		switch (dns_gethostbyname(this->server.c_str(), &resolved,
-				staticDnsResponse, (void*) this))
-		{
-		case ERR_OK:
-			serverAddress = resolved;
-			return 1;
-			break;
-		case ERR_INPROGRESS:
-			return 0; // currently finding ip, requestTime() will be called later.
-		default:
-			debugf("DNS Lookup error occurred.");
-			return 0;
-		}
-	}
-
-	return 0;
-}
 
 void NtpClient::requestTime()
 {
@@ -67,16 +51,38 @@ void NtpClient::requestTime()
 		connectionTimer.initializeMs(1000, TimerDelegate(&NtpClient::requestTime, this)).startOnce();
 		return;
 	}
-	if (serverAddress.isNull())
-	{
-		if (!resolveServer())
-		{
-			return;
-		}
-	}
 
-//	connect to current active serverAddress, on NTP_PORT
-	this->connect(serverAddress,NTP_PORT);
+	struct ip_addr resolvedIp;
+	int result = dns_gethostbyname(this->server.c_str(), &resolvedIp,
+			staticDnsResponse, (void*) this);
+
+	switch (result)
+	{
+	case ERR_OK:
+		// Documentation says this will be the result if the string is already
+		// an ip address in dotted decimal form or if the host is found in dns cache.
+		// however I'm not sure if the dns cache is working since this never seems to
+		// be called for a host lookup other than an ip address.
+		// Doesn't really matter since the loockup will be fast anyways, the host
+		// is most likely found in the dns cache of the next node the query is sent to.
+		internalRequestTime(resolvedIp);
+		break;
+	case ERR_INPROGRESS:
+		// currently finding ip, internalRequestTime() will be called when its found.
+		//debugf("DNS IP lookup in progress.");
+		break;
+	default:
+		debugf("DNS lookup error occurred.");
+		break;
+	}
+}
+
+
+void NtpClient::internalRequestTime(IPAddress serverIp)
+{
+
+	// connect to current active serverIp, on NTP_PORT
+	this->connect(serverIp,NTP_PORT);
 
 	uint8_t packet[NTP_PACKET_SIZE];
 
@@ -84,26 +90,24 @@ void NtpClient::requestTime()
 	memset(packet, 0, NTP_PACKET_SIZE);
 
 	// These are the only required values for a SNTP request. See page 14:
-	// https://tools.ietf.org/html/rfc4330 
+	// https://tools.ietf.org/html/rfc4330
 	// However size of packet should still be 48 bytes.
 	packet[0] = (NTP_VERSION << 3 | 0x03); // LI (0 = no warning), Protocol version (4), Client mode (3)
 	packet[1] = 0;     	// Stratum, or type of clock, unspecified.
 
-//	Send to server, serverAddress & port is set in connect
+
+	// Start timeout timer, if no response is recieved within NTP_RESPONSE_TIMEOUT
+	// a new request will be sent.
+	timeoutTimer.startOnce();
+
+	// Send to server, serverAddress & port is set in connect
 	NtpClient::send((char*) packet, NTP_PACKET_SIZE);
 }
+
 
 void NtpClient::setNtpServer(String server)
 {
 	this->server = server;
-	// force new DNS lookup
-	serverAddress = (uint32_t)0;
-}
-
-void NtpClient::setNtpServer(IPAddress serverIp)
-{
-	this->server = NULL;
-	this->serverAddress = serverIp;
 }
 
 void NtpClient::setAutoQuery(bool autoQuery)
@@ -130,6 +134,12 @@ void NtpClient::setAutoUpdateSystemClock(bool autoUpdateClock)
 
 void NtpClient::onReceive(pbuf *buf, IPAddress remoteIP, uint16_t remotePort)
 {
+	// stop timeout timer since we received a response.
+	if(timeoutTimer.isStarted()) {
+		timeoutTimer.stop();
+	}
+
+
 	// We do some basic check to see if it really is a ntp packet we receive.
 	// NTP version should be set to same as we used to send, NTP_VERSION
 	// NTP_VERSION 3 has time in same location so accept that too
@@ -172,8 +182,7 @@ void NtpClient::staticDnsResponse(const char *name, struct ip_addr *ip, void *ar
 
 	if (ip != NULL)
 	{
-		self->serverAddress = *ip;
 		// We do a new request since the last one was never done.
-		self->requestTime();
+		self->internalRequestTime(*ip);
 	}
 }

--- a/Sming/SmingCore/Network/NtpClient.h
+++ b/Sming/SmingCore/Network/NtpClient.h
@@ -14,14 +14,16 @@
 #define NTP_MODE_CLIENT 3
 #define NTP_MODE_SERVER 4
 
-#define NTP_SERVER_DEFAULT "pool.ntp.org"
-
-#define NTP_DEFAULT_AUTO_UPDATE_INTERVAL 600000 // 10 minutes
+#define NTP_DEFAULT_SERVER "pool.ntp.org"
+#define NTP_DEFAULT_QUERY_INTERVAL_SECONDS 600 // 10 minutes
+#define NTP_RESPONSE_TIMEOUT_MS 20000 // 20 seconds
 
 class NtpClient;
 
 // Delegate constructor usage: (&YourClass::method, this)
 typedef Delegate<void(NtpClient& client, time_t ntpTime)> NtpTimeResultDelegate;
+
+
 
 class NtpClient : protected UdpConnection
 {
@@ -34,7 +36,6 @@ public:
 	void requestTime();
 	
 	void setNtpServer(String server);
-	void setNtpServer(IPAddress adress);
 	
 	void setAutoQuery(bool autoQuery);
 	void setAutoQueryInterval(int seconds);
@@ -42,16 +43,17 @@ public:
 	void setAutoUpdateSystemClock(bool autoUpdateClock);
 
 protected:
-	int resolveServer();
 	void onReceive(pbuf *buf, IPAddress remoteIP, uint16_t remotePort);
-	
+	void internalRequestTime(IPAddress serverIp);
+
 protected: 
-	String server = NTP_SERVER_DEFAULT;
-	IPAddress serverAddress = (uint32_t)0;
+	String server = NTP_DEFAULT_SERVER;
+
 	NtpTimeResultDelegate delegateCompleted = nullptr;
 	bool autoUpdateSystemClock = false;
 		
 	Timer autoUpdateTimer;
+	Timer timeoutTimer;
 	Timer connectionTimer;
 		
 	static void staticDnsResponse(const char *name, struct ip_addr *ip, void *arg);		

--- a/Sming/SmingCore/Platform/RTC.cpp
+++ b/Sming/SmingCore/Platform/RTC.cpp
@@ -16,12 +16,11 @@ uint32_t RtcClass::getRtcSeconds() {
 
 
 bool RtcClass::setRtcSeconds(uint32_t seconds) {
-
 	RtcData rtcTime;
 	loadTime(rtcTime);
-	uint64_t offsetNs = ((uint64_t) seconds * NS_PER_SECOND) - rtcTime.time;
-	rtcTime.time += offsetNs; // adjust time in nanoseconds by the ntp time offset in nanoseconds
 	updateTime(rtcTime);
+	uint64_t time= ((uint64_t) seconds * NS_PER_SECOND);
+	rtcTime.time = time;
 	return saveTime(rtcTime);
 }
 

--- a/Sming/SmingCore/Timer.h
+++ b/Sming/SmingCore/Timer.h
@@ -8,9 +8,16 @@
 #ifndef _SMING_CORE_Timer_H_
 #define _SMING_CORE_Timer_H_
 
+
 #include "../SmingCore/Interrupts.h"
 #include "../SmingCore/Delegate.h"
 #include "../Wiring/WiringFrameworkDependencies.h"
+
+
+// Default timer is millisecond timer and the maximum value is 6871947ms.
+// After call system_timer_reinit,the timer will change to microsecond,
+// timer and the maximum value of os_timer_arm() is 429496ms.
+#define MAX_OS_TIMER_INTERVAL_US 420000000  // some haedroom ;)
 
 typedef Delegate<void()> TimerDelegate;
 
@@ -37,10 +44,10 @@ public:
 	void IRAM_ATTR restart();
 	bool isStarted();
 
-	uint32_t getIntervalUs();
+	uint64_t getIntervalUs();
 	uint32_t getIntervalMs();
 
-    void IRAM_ATTR setIntervalUs(uint32_t microseconds = 1000000);
+    void IRAM_ATTR setIntervalUs(uint64_t microseconds = 1000000);
     void IRAM_ATTR setIntervalMs(uint32_t milliseconds = 1000000);
 
     void IRAM_ATTR setCallback(InterruptCallback interrupt = NULL);
@@ -56,6 +63,12 @@ private:
     InterruptCallback callback = nullptr;
     TimerDelegate delegate_func = nullptr;
     bool started = false;
+
+
+    // Because of the limitation in Espressif SDK a workargound
+    // was added to allow for longer timer intervals.
+    uint16_t long_intvl_cntr = 0;
+    uint16_t long_intvl_cntr_lim = 0;
 };
 
 #endif /* _SMING_CORE_Timer_H_ */


### PR DESCRIPTION
Bug fixes + timeout support in NtpClinet . Discussed in Issue #67 
Workaround for supporting long intervals in Sming Timer. Fix Issue #67 
Fixed bug in RTC setRtcSeconds causing the wrong time to be set. Fix Issue #203 