### PR TITLE
fix systemDebugOutput()

### DIFF
--- a/Sming/Services/SpifFS/spiffs_config.h
+++ b/Sming/Services/SpifFS/spiffs_config.h
@@ -23,7 +23,7 @@
 #define SPIFFS_CHACHE 0
 
 #define c_memcpy os_memcpy
-#define c_printf os_printf
+#define c_printf m_printf
 #define c_memset os_memset
 
 /*typedef int32_t s32_t;

--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -17,6 +17,9 @@
 // UartDev is defined and initialized in ROM code.
 extern UartDevice UartDev;
 
+//set m_printf callback
+extern void setMPrintfPrinterCbc(void (*callback)(char));
+
 // StreamDataAvailableDelegate HardwareSerial::HWSDelegates[2];
 
 HWSerialMemberData HardwareSerial::memberData[NUMBER_UARTS];
@@ -157,7 +160,7 @@ void HardwareSerial::flush()
 void HardwareSerial::systemDebugOutput(bool enabled)
 {
 	if (uart == UART_ID_0)
-		os_install_putc1(enabled ? (void *)uart_tx_one_char : NULL);
+		setMPrintfPrinterCbc(enabled ? uart_tx_one_char : NULL);
 	//else
 	//	os_install_putc1(enabled ? (void *)uart1_tx_one_char : NULL); //TODO: Debug serial
 }

--- a/Sming/system/include/arch/cc.h
+++ b/Sming/system/include/arch/cc.h
@@ -76,7 +76,7 @@ typedef unsigned long   mem_ptr_t;
 //#define LWIP_DEBUG
 
 #ifdef LWIP_DEBUG
-#define LWIP_PLATFORM_DIAG(x) os_printf x
+#define LWIP_PLATFORM_DIAG(x) m_printf x
 #define LWIP_PLATFORM_ASSERT(x) ETS_ASSERT(x)
 #else
 #define LWIP_PLATFORM_DIAG(x)

--- a/Sming/system/include/esp_systemapi.h
+++ b/Sming/system/include/esp_systemapi.h
@@ -31,7 +31,7 @@ extern int m_printf(const char *fmt, ...);
 #undef assert
 #define debugf(fmt, ...) m_printf(fmt"\r\n", ##__VA_ARGS__)
 #define assert(condition) if (!(condition)) SYSTEM_ERROR("ASSERT: %s %d", __FUNCTION__, __LINE__)
-#define SYSTEM_ERROR(fmt, ...) os_printf("ERROR: " fmt "\r\n", ##__VA_ARGS__)
+#define SYSTEM_ERROR(fmt, ...) m_printf("ERROR: " fmt "\r\n", ##__VA_ARGS__)
 
 extern void ets_timer_arm_new(ETSTimer *ptimer, uint32_t milliseconds, bool repeat_flag, int isMstimer);
 extern void ets_timer_disarm(ETSTimer *a);

--- a/Sming/system/include/lwip/app/espconn.h
+++ b/Sming/system/include/lwip/app/espconn.h
@@ -5,7 +5,7 @@
 #include "os_type.h"
 
 #if 0
-#define espconn_printf(fmt, args...) os_printf(fmt,## args)
+#define espconn_printf(fmt, args...) m_printf(fmt,## args)
 #else 
 #define espconn_printf(fmt, args...)
 #endif

--- a/Sming/system/m_printf.cpp
+++ b/Sming/system/m_printf.cpp
@@ -34,6 +34,11 @@ void setMPrintfPrinterCbc(void (*callback)(char))
 
 int m_printf(const char *fmt, ...)
 {
+	if(!cbc_printchar)
+	{
+		return 0;
+	}
+
 	char buf[MPRINTF_BUF_SIZE], *p;
 	va_list args;
 	int n = 0;
@@ -144,6 +149,7 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args)
 			break;
 
 		case 'x':
+		case 'X':
 			*str++ = '0';
 			*str++ = 'x';
 			base = 16;


### PR DESCRIPTION
* fix systemDebugOutput()
* remove os_printf from framework to only use m_printf alternative
* support %X format specifier, but still prints lowercase

Testcases for m_printf can be found in Sming/Basic_Serial/app/application.cpp

Thanks