### PR TITLE
spiffs mounting improvements

### DIFF
--- a/Sming/Services/SpifFS/spiffs.h
+++ b/Sming/Services/SpifFS/spiffs.h
@@ -457,9 +457,11 @@ u32_t SPIFFS_buffer_bytes_for_cache(spiffs *fs, u32_t num_pages);
 
 
 void spiffs_mount();
+void spiffs_mount_manual(u32_t phys_addr, u32_t phys_size);
 void spiffs_unmount();
 bool spiffs_format();
-bool spiffs_format_internal();
+bool spiffs_format_internal(spiffs_config *cfg);
+bool spiffs_format_manual(u32_t phys_addr, u32_t phys_size);
 spiffs_config spiffs_get_storage_config();
 extern void test_spiffs();
 

--- a/Sming/SmingCore/Network/HttpFirmwareUpdate.cpp
+++ b/Sming/SmingCore/Network/HttpFirmwareUpdate.cpp
@@ -33,8 +33,8 @@ void HttpFirmwareUpdate::start()
 {
 	WDT.enable(false);
 	spiffs_unmount();
-	spiffs_format_internal();
 	spiffs_config cfg = spiffs_get_storage_config();
+	spiffs_format_internal(&cfg);
 	pos = cfg.phys_addr;
 
 	timer.initializeMs(500, TimerDelegate(&HttpFirmwareUpdate::onTimer, this)).start();


### PR DESCRIPTION
Allows the location and length of the spiffs to be specified by the app, the app
should be compiled with DISABLE_SPIFFS to prevent auto mounting and then call
spiffs_mount_manual with the desired parameters from the init function.

This was requested by rBoot users and allows mounting of multiple different
spiffs images along side multiple OTAable rom images.