### PR TITLE
input fix: remove clear of pullup when not explicitly cleared

### DIFF
--- a/Sming/SmingCore/Digital.cpp
+++ b/Sming/SmingCore/Digital.cpp
@@ -53,10 +53,6 @@ void pinMode(uint16_t pin, uint8_t mode)
 	{
 		pullup(pin);
 	}
-	else if (mode == INPUT)
-	{
-		noPullup(pin);
-	}
 }
 
 //Detect if pin is input


### PR DESCRIPTION
Pullup is cleared when pin set to input even if not explicitly cleared by digitalWrite(LOW).

This affects interrupts and other places where 
1. pin is input pullup is enabled 
2. pin is set to input again

Fixes #242 