### PR TITLE
core:nw:Add method to get content of request header

### DIFF
--- a/Sming/SmingCore/Network/HttpRequest.h
+++ b/Sming/SmingCore/Network/HttpRequest.h
@@ -32,6 +32,7 @@ public:
 
 	inline String getRequestMethod() { return method; }
 	inline String getPath() { return path; }
+	inline String getHeaderData() { return content; }
 	String getContentType();
 	int getContentLength();
 
@@ -46,6 +47,7 @@ public:
 public:
 	HttpParseResult parseHeader(HttpServer *server, pbuf* buf);
 	HttpParseResult parsePostData(HttpServer *server, pbuf* buf);
+	HttpParseResult parseHeaderData(HttpServer *server, pbuf* buf);
 	bool extractParsingItemsList(pbuf* buf, int startPos, int endPos,
 			char delimChar, char endChar,
 			HashMap<String, String> *resultItems);
@@ -53,6 +55,7 @@ public:
 private:
 	String method;
 	String path;
+	String content;
 	HashMap<String, String> *requestHeaders;
 	HashMap<String, String> *requestGetParameters;
 	HashMap<String, String> *requestPostParameters;

--- a/Sming/SmingCore/Network/HttpServerConnection.cpp
+++ b/Sming/SmingCore/Network/HttpServerConnection.cpp
@@ -56,9 +56,7 @@ err_t HttpServerConnection::onReceive(pbuf *buf)
 			debugf("Request: %s, %s", request.getRequestMethod().c_str(),
 					(request.getContentLength() > 0 ? (String(request.getContentLength()) + " bytes").c_str() : "nodata"));
 
-			String contType = request.getContentType();
-			contType.toLowerCase();
-			if (request.getContentLength() > 0 && contType.indexOf(ContentType::FormUrlEncoded) != -1)
+			if (request.getContentLength() > 0)
 				state = eHCS_ParsePostData;
 			else
 				state = eHCS_ParsingCompleted;
@@ -71,7 +69,14 @@ err_t HttpServerConnection::onReceive(pbuf *buf)
 
 	if (state == eHCS_ParsePostData)
 	{
-		HttpParseResult res = request.parsePostData(server, buf);
+		HttpParseResult res;
+		String contType = request.getContentType();
+		contType.toLowerCase();
+		if (contType.indexOf(ContentType::FormUrlEncoded) != -1)
+			res = request.parsePostData(server, buf);
+		else
+			res = request.parseHeaderData(server, buf);
+
 		if (res == eHPR_Wait)
 			debugf("POST WAIT");
 		else if (res == eHPR_Failed)


### PR DESCRIPTION
There is no way to get access to content of a request header unless
header content is of type "ContentType::FormUrlEncoded". So added a new
method HttpRequest::getHeaderData() to return header content as a String.

So if you are posing data to HTTP server with mime type different than
"application/x-www-form-urlencoded", you can use getHeaderData in
http request callback function for parsing.

Signed-off-by: Ajay Bhargav <contact@rickeyworld.info>