### PR TITLE
resubmit: Add --dtr 0 --rts 0 options to miniterm.py

### DIFF
--- a/Sming/Makefile-bsd.mk
+++ b/Sming/Makefile-bsd.mk
@@ -12,5 +12,5 @@ SDK_TOOLS	 ?= $(SDK_BASE)/tools
 ESPTOOL		 ?= $(ESP_HOME)/esptool/esptool.py
 KILL_TERM    ?= pkill -9 -f "$(COM_PORT) $(COM_SPEED_SERIAL)" || exit 0
 GET_FILESIZE ?= stat -f "%-15z"
-TERMINAL     ?= python -m serial.tools.miniterm $(COM_PORT) $(COM_SPEED_SERIAL)
+TERMINAL     ?= python -m serial.tools.miniterm $(COM_PORT) $(COM_SPEED_SERIAL) --dtr 0 --rts 0
 MEMANALYZER  ?= $(OBJDUMP) -h -j .data -j .rodata -j .bss -j .text -j .irom0.text

--- a/Sming/Makefile-linux.mk
+++ b/Sming/Makefile-linux.mk
@@ -12,5 +12,5 @@ SDK_TOOLS	 ?= $(SDK_BASE)/tools
 ESPTOOL		 ?= $(ESP_HOME)/esptool/esptool.py
 KILL_TERM    ?= pkill -9 -f "$(COM_PORT) $(COM_SPEED_SERIAL)" || exit 0
 GET_FILESIZE ?= stat --printf="%s"
-TERMINAL     ?= python -m serial.tools.miniterm $(COM_PORT) $(COM_SPEED_SERIAL)
+TERMINAL     ?= python -m serial.tools.miniterm $(COM_PORT) $(COM_SPEED_SERIAL) --dtr 0 --rts 0
 MEMANALYZER  ?= $(OBJDUMP) -h -j .data -j .rodata -j .bss -j .text -j .irom0.text

--- a/Sming/Makefile-macos.mk
+++ b/Sming/Makefile-macos.mk
@@ -12,5 +12,5 @@ SDK_TOOLS	 ?= $(SDK_BASE)/tools
 ESPTOOL		 ?= $(ESP_HOME)/esptool/esptool.py
 KILL_TERM    ?= pkill -9 -f "$(COM_PORT) $(COM_SPEED_SERIAL)" || exit 0
 GET_FILESIZE ?= stat -L -f%z
-TERMINAL     ?= python -m serial.tools.miniterm $(COM_PORT) $(COM_SPEED_SERIAL)
+TERMINAL     ?= python -m serial.tools.miniterm $(COM_PORT) $(COM_SPEED_SERIAL) --dtr 0 --rts 0
 MEMANALYZER  ?= $(OBJDUMP) -h -j .data -j .rodata -j .bss -j .text -j .irom0.text


### PR DESCRIPTION
On good devboards with proper reset circuit it will reset esp8266 on every miniterm.py reconnect, no harm on other boards.