### PR TITLE
Fix I2C bus driver: in SoftI2cMaster::start set SDA & SCL HIGH at the begining

### DIFF
--- a/Sming/Wiring/I2cMaster.cpp
+++ b/Sming/Wiring/I2cMaster.cpp
@@ -94,6 +94,9 @@ bool SoftI2cMaster::restart(uint8_t addressRW) {
  * \return The value true, 1, for success or false, 0, for failure.
  */
 bool SoftI2cMaster::start(uint8_t addressRW) {
+  digitalWrite(sdaPin_, HIGH);
+  digitalWrite(sclPin_, HIGH);
+  delayMicroseconds(I2C_DELAY_USEC);
   digitalWrite(sdaPin_, LOW);
   delayMicroseconds(I2C_DELAY_USEC);
   digitalWrite(sclPin_, LOW);


### PR DESCRIPTION
In SoftI2cMaster::start there was wrong assumption that SDA & SCL are both HIGH at the time this method is calling. Fixup this enables proper I2C start condition. Tested on DS3231 - without this fix every second try to read from I2C slave fails, with - do not.