### PR TITLE
Add overloading to provide compatibility to old version codes

### DIFF
--- a/Sming/Libraries/IR/IRremote.cpp
+++ b/Sming/Libraries/IR/IRremote.cpp
@@ -27,6 +27,12 @@ IRsend::IRsend(int sendpin)
   irparams.sendpin = sendpin;
 }
 
+//provide backwards compatibility
+IRsend::IRsend()
+{
+  irparams.sendpin = 0;
+}
+
 void IRsend::sendNEC(unsigned long data, int nbits)
 {
   enableIROut(38);

--- a/Sming/Libraries/IR/IRremote.cpp
+++ b/Sming/Libraries/IR/IRremote.cpp
@@ -30,7 +30,7 @@ IRsend::IRsend(int sendpin)
 //provide backwards compatibility
 IRsend::IRsend()
 {
-  irparams.sendpin = 0;
+  irparams.sendpin = 13;
 }
 
 void IRsend::sendNEC(unsigned long data, int nbits)

--- a/Sming/Libraries/IR/IRremote.h
+++ b/Sming/Libraries/IR/IRremote.h
@@ -97,6 +97,7 @@ class IRsend
 {
 public:
   IRsend(int sendpin);
+  IRsend();
   void sendWhynter(unsigned long data, int nbits);
   void sendNEC(unsigned long data, int nbits);
   void sendSony(unsigned long data, int nbits);


### PR DESCRIPTION
Added overload with default pin 0. 

This PR is linked to https://github.com/anakod/Sming/pull/277.