### PR TITLE
Fix for #283 si4432 compile error on MingGW

### DIFF
--- a/Sming/Libraries/si4432/si4432.cpp
+++ b/Sming/Libraries/si4432/si4432.cpp
@@ -391,7 +391,7 @@ void Si4432::readAll() {
 
 	debugf("REGS  00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F");
 
-	for (unsigned int i = 0; i < 0x7f; i+=16)
+	for (byte i = 0; i < 0x7f; i+=16)
 	{
 		debugf("(%02x): %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x", i,
 				(int ) allValues[i+0], (int ) allValues[i+1], (int ) allValues[i+2], (int ) allValues[i+3],

--- a/Sming/Libraries/si4432/si4432.cpp
+++ b/Sming/Libraries/si4432/si4432.cpp
@@ -385,13 +385,13 @@ void Si4432::BurstRead(Registers startReg, byte value[], uint8_t length) {
 
 void Si4432::readAll() {
 
-	byte allValues[0x7F];
+	byte allValues[0x80];
 
 	BurstRead(REG_DEV_TYPE, allValues, 0x7F);
 
 	debugf("REGS  00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F");
 
-	for (byte i = 0; i < 0x7f; i+=16)
+	for (unsigned int i = 0; i < 0x7f; i+=16)
 	{
 		debugf("(%02x): %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x", i,
 				(int ) allValues[i+0], (int ) allValues[i+1], (int ) allValues[i+2], (int ) allValues[i+3],


### PR DESCRIPTION
this fixes #283:

# Solution
The fix just increases the buffer size by one. 

# Testing

I personally can't test the code at runtime for lack of this device. Tested compilation though.

