### PR TITLE
few rBoot integration changes

### DIFF
--- a/Accelerometer_MMA7455/Makefile
+++ b/Accelerometer_MMA7455/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Basic_AirUpdate/Makefile
+++ b/Basic_AirUpdate/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Basic_Blink/Makefile
+++ b/Basic_Blink/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Basic_Capsense/Makefile
+++ b/Basic_Capsense/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Basic_Interrupts/Makefile
+++ b/Basic_Interrupts/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Basic_PWM/Makefile
+++ b/Basic_PWM/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Basic_ProgMem/Makefile
+++ b/Basic_ProgMem/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Basic_ScannerI2C/Makefile
+++ b/Basic_ScannerI2C/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Basic_Serial/Makefile
+++ b/Basic_Serial/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Basic_SmartConfig/Makefile
+++ b/Basic_SmartConfig/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Basic_WiFi/Makefile
+++ b/Basic_WiFi/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Basic_rBoot/readme.txt
+++ b/Basic_rBoot/readme.txt
@@ -17,10 +17,15 @@ Makefile-user.mk
 
 Building
 --------
- 1) Set ESP_HOME & SMING_HOME, as environment variables or edit the Makefile, as
-    you would for general Sming compiling.
- 2) Set ESPTOOL2 (env var or in the Makefile) to point to the esptool2 binary.
- 3) Set WIFI_SSID & WIFI_PWD environment variable with your wifi details.
+ 0) Set environment variable DISABLE_SPIFFS_AUTO=1 before building Sming itself
+    (libsming), this prevents Sming trying to auto-mount a spiffs filesystem
+    from the wrong flash location (which is potentially destructive to flash
+    contents).
+ 1) Set ESP_HOME & SMING_HOME, as environment variables or edit Makefile-user.mk
+    as you would for general Sming app compiling.
+ 2) Set ESPTOOL2 (env var or in Makefile-user.mk) to point to the esptool2
+    binary.
+ 3) Set WIFI_SSID & WIFI_PWD environment variables with your wifi details.
  4) Edit the OTA server details in include/user_config.h
  5) Check overridable variables in Makefile-user.mk, or set as env vars.
  6) make && make flash

--- a/Compass_HMC5883L/Makefile
+++ b/Compass_HMC5883L/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/FtpServer_Files/Makefile
+++ b/FtpServer_Files/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/HttpClient_Instapush/Makefile
+++ b/HttpClient_Instapush/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/HttpClient_ThingSpeak/Makefile
+++ b/HttpClient_ThingSpeak/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/HttpServer_AJAX/Makefile
+++ b/HttpServer_AJAX/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/HttpServer_Bootstrap/Makefile
+++ b/HttpServer_Bootstrap/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/HttpServer_ConfigNetwork/Makefile
+++ b/HttpServer_ConfigNetwork/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/HttpServer_WebSockets/Makefile
+++ b/HttpServer_WebSockets/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Humidity_DHT22/Makefile
+++ b/Humidity_DHT22/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/IR_lib/Makefile
+++ b/IR_lib/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/LED_WS2812/Makefile
+++ b/LED_WS2812/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Light_BH1750/Makefile
+++ b/Light_BH1750/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/LiquidCrystal_44780/Makefile
+++ b/LiquidCrystal_44780/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/MeteoControl/Makefile
+++ b/MeteoControl/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/MqttClient_Hello/Makefile
+++ b/MqttClient_Hello/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Pressure_BMP180/Makefile
+++ b/Pressure_BMP180/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Radio_nRF24L01/Makefile
+++ b/Radio_nRF24L01/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Radio_si4432/Makefile
+++ b/Radio_si4432/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/SDCard/Makefile
+++ b/SDCard/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/ScreenLCD_5110/Makefile
+++ b/ScreenLCD_5110/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/ScreenOLED_SSD1306/Makefile
+++ b/ScreenOLED_SSD1306/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/ScreenTFT_ILI9163C/Makefile
+++ b/ScreenTFT_ILI9163C/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/ScreenTFT_ILI9340-ILI9341/Makefile
+++ b/ScreenTFT_ILI9340-ILI9341/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -160,6 +160,9 @@ MODULE_INCDIR	:= $(addsuffix /include,$(INCDIR))
 ifeq ($(DISABLE_SPIFFS), 1)
 	CFLAGS += -DDISABLE_SPIFFS=1
 endif
+ifeq ($(DISABLE_SPIFFS_AUTO), 1)
+	CFLAGS += -DDISABLE_SPIFFS_AUTO=1
+endif
 
 V ?= $(VERBOSE)
 ifeq ("$(V)","1")
@@ -200,6 +203,9 @@ $(APP_AR): $(OBJ)
 	$(vecho) "Installing libsming"
 ifeq ($(DISABLE_SPIFFS), 1)
 	$(vecho) "(!) Spiffs support disabled. Remove 'DISABLE_SPIFFS' make argument to enable spiffs."
+endif
+ifeq ($(DISABLE_SPIFFS_AUTO), 1)
+	$(vecho) "(!) Spiffs auto-mount disabled. Call spiffs_mount or spiffs_mount_manual from init to use spiffs."
 endif
 	$(Q) cp -r $(APP_AR) $(USER_LIBDIR)/libsming.a  
 	$(vecho) "Done"

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -170,7 +170,7 @@ ifeq ($(DISABLE_SPIFFS), 1)
 endif
 
 # linker flags used to generate the main object file
-LDFLAGS		= -nostdlib -u call_user_start -u Cache_Read_Enable_New -u user_init -Wl,-static -Wl,--gc-sections -Wl,-Map=$(basename $@).map
+LDFLAGS		= -nostdlib -u call_user_start -u Cache_Read_Enable_New -Wl,-static -Wl,--gc-sections -Wl,-Map=$(basename $@).map
 
 ifeq ($(SPI_SPEED), 26)
 	flashimageoptions = -ff 26m

--- a/SystemClock_NTP/Makefile
+++ b/SystemClock_NTP/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/TcpClient_NarodMon/Makefile
+++ b/TcpClient_NarodMon/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Telnet_TCPServer_TCPClient/Makefile
+++ b/Telnet_TCPServer_TCPClient/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Temperature_DS1820/Makefile
+++ b/Temperature_DS1820/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/UdpServer_Echo/Makefile
+++ b/UdpServer_Echo/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/UdpServer_mDNS/Makefile
+++ b/UdpServer_mDNS/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Ultrasonic_HCSR04/Makefile
+++ b/Ultrasonic_HCSR04/Makefile
@@ -17,4 +17,8 @@ $(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
 endif
 
 # Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
 include $(SMING_HOME)/Makefile-project.mk
+endif


### PR DESCRIPTION
workaround a bug (#294), a gcc linking oddity and make all sample makefiles rboot aware