### PR TITLE
Wait for header parsing to writeRawData

### DIFF
--- a/Sming/SmingCore/Network/HttpClient.cpp
+++ b/Sming/SmingCore/Network/HttpClient.cpp
@@ -254,7 +254,7 @@ err_t HttpClient::onReceive(pbuf *buf)
 			}
 		}
 
-		writeRawData(buf, startPos);
+		if (!waitParse) writeRawData(buf, startPos);
 
 		// Fire ReadyToSend callback
 		TcpClient::onReceive(buf);


### PR DESCRIPTION
Some web servers (python 2.7 SimpleHTTPServer, at least), send the HTTP/1.1 200 OK line as one packet, the headers in the next packet, and the body starting in the third packet.  Without this change, writeRawData will write the headers on these servers, but start with the body on servers that send the status code and headers together in one packet.  By waiting until the headerEnd is confirmed, this makes the HTTP client act consistently across all servers.